### PR TITLE
check if `id` is nil before we stringify it

### DIFF
--- a/json_rpc/router.nim
+++ b/json_rpc/router.nim
@@ -58,7 +58,7 @@ proc wrapError*(code: int, msg: string, id: JsonNode = newJNull(),
   # Error reply that carries version, id and error object only
   StringOfJson(
     """{"jsonrpc":"2.0","id":$1,"error":{"code":$2,"message":$3,"data":$4}}""" % [
-      $id, $code, escapeJson(msg), $data
+      (if isNil(id): "unknown" else: $id), $code, escapeJson(msg), $data
     ] & "\r\n")
 
 proc hasReturnType(params: NimNode): bool =


### PR DESCRIPTION
Some clients do not send proper id value. 

The original repo also has this issue, not sure if I should try to land this code in there as well